### PR TITLE
Fix Python server loading 0 tools (import regression)

### DIFF
--- a/python/src/omnifocus_mcp/__main__.py
+++ b/python/src/omnifocus_mcp/__main__.py
@@ -1,4 +1,5 @@
-from omnifocus_mcp.app import mcp
+# Import from server, not app — this import triggers tool registration as a side effect
+from omnifocus_mcp.server import mcp
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

- `__main__.py` imports `mcp` from `app.py`, which creates a bare `FastMCP` instance with **zero tools registered**
- The correct import is from `server.py`, which imports the tool modules whose `@typed_tool` decorators register all 49 tools as a side effect
- This was introduced in commit `173c86b` ("ralph: implement state tracker") — a one-line import change that silently broke the Python entry point

## Change

One-line fix in `python/src/omnifocus_mcp/__main__.py`:

```diff
-from omnifocus_mcp.app import mcp
+from omnifocus_mcp.server import mcp
```

This restores the original import path from before the regression.

## Testing

- Verified the Python server starts and exposes all 49 tools via JSON-RPC `tools/list`
- Confirmed `app.py` only creates the bare FastMCP instance (no tool imports)
- Confirmed `server.py` imports all tool modules, triggering registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)